### PR TITLE
Yii2 2.0.15 compatibility update

### DIFF
--- a/NProgressAsset.php
+++ b/NProgressAsset.php
@@ -99,7 +99,7 @@ jQuery(document).on('ajaxStart',    function() { NProgress.start(); });
 jQuery(document).on('ajaxComplete', function() { NProgress.done();  });                    
 AJAX;
             $view->registerJs($jsAjax, View::POS_END);
-            $this->depends[] = 'yii\widgets\JqueryAsset';
+            $this->depends[] = 'yii\web\JqueryAsset';
         }
 
         parent::registerAssetFiles($view);


### PR DESCRIPTION
As of Yii2 2.0.15, `yii\widgets\JqueryAsset` no longer exists and `yii\web\JqueryAsset` should be used.